### PR TITLE
VK fixes

### DIFF
--- a/integration/omm-sdk-nvrhi/omm-sdk-nvrhi.h
+++ b/integration/omm-sdk-nvrhi/omm-sdk-nvrhi.h
@@ -27,8 +27,12 @@ namespace omm
 	{
 	public:
 
-		// In case the shaders are compiled externally the ShaderProviderCb can be used.
-		using ShaderProviderCb = std::function<nvrhi::ShaderHandle(nvrhi::ShaderType type, const char* shaderName, const char* shaderEntryName)>;
+		// (Optional) In case the shaders are compiled externally the ShaderProvider can be provided 
+		struct ShaderProvider
+		{
+			nvrhi::VulkanBindingOffsets bindingOffsets;
+			std::function<nvrhi::ShaderHandle(nvrhi::ShaderType type, const char* shaderName, const char* shaderEntryName)> shaders;
+		};
 
 		enum class Operation
 		{
@@ -114,7 +118,7 @@ namespace omm
 			uint32_t totalFullyUnknownTransparent = 0;
 		};
 
-		GpuBakeNvrhi(nvrhi::DeviceHandle device, nvrhi::CommandListHandle commandList, bool enableDebug, ShaderProviderCb* shaderProviderCb = nullptr);
+		GpuBakeNvrhi(nvrhi::DeviceHandle device, nvrhi::CommandListHandle commandList, bool enableDebug, ShaderProvider* shaderProvider = nullptr);
 		~GpuBakeNvrhi();
 
 		// CPU side pre-build info.

--- a/omm-sdk/ShaderCompilation.cmake
+++ b/omm-sdk/ShaderCompilation.cmake
@@ -139,7 +139,7 @@ macro(list_hlsl_shaders OMM_HLSL_FILES OMM_HEADER_FILES OMM_SHADER_FILES)
             if (NOT "${DXC_PROFILE}" STREQUAL "")
                 add_custom_command(
                         OUTPUT ${OUTPUT_PATH_SPIRV} ${OUTPUT_PATH_SPIRV}.h
-                        COMMAND ${OMM_VULKAN_DXC_SPIRV_PATH} -E main -DCOMPILER_DXC=1 -DVULKAN=1 -T ${DXC_PROFILE}
+                        COMMAND ${OMM_VULKAN_DXC_SPIRV_PATH} -E main -DCOMPILER_DXC=1 -T ${DXC_PROFILE}
                             -I "${OMM_HEADER_INCLUDE_PATH}" ${DXC_ADDITIONAL_OPTIONS} -I "${OMM_SHADER_INCLUDE_PATH}"
                             ${FILE_NAME} -spirv -Vn g_${BYTECODE_ARRAY_NAME}_spirv -Fh ${OUTPUT_PATH_SPIRV}.h
                             -Fo ${OUTPUT_PATH_SPIRV} ${OMM_DXC_VK_SHIFTS} -fspv-target-env=vulkan1.1

--- a/omm-sdk/shaders/platform.hlsli
+++ b/omm-sdk/shaders/platform.hlsli
@@ -11,10 +11,10 @@ license agreement from NVIDIA CORPORATION is strictly prohibited.
 #ifndef PLATFORM_HLSLI
 #define PLATFORM_HLSLI
 
-#ifdef VULKAN
+#ifdef __spirv__
 #define ALLOW_UAV_CONDITION
 #define VK_PUSH_CONSTANT [[vk::push_constant]]
-#else // DXC
+#else // dxil
 #define ALLOW_UAV_CONDITION [allow_uav_condition]
 #define VK_PUSH_CONSTANT
 #endif


### PR DESCRIPTION
* Removing VK-specific define "#define VULKAN" and instead relying on built in define __spirv__
* Exposing option to set SPIRV-binding offsets when supplying shader externally in the nvrhi integration layer