### PR TITLE
GPU stats in post dispatch info

### DIFF
--- a/integration/omm-sdk-nvrhi/omm-sdk-nvrhi.cpp
+++ b/integration/omm-sdk-nvrhi/omm-sdk-nvrhi.cpp
@@ -615,9 +615,11 @@ omm::Gpu::DispatchConfigDesc GpuBakeNvrhiImpl::GetConfig(const GpuBakeNvrhi::Inp
 	if (((uint32_t)params.operation & (uint32_t)GpuBakeNvrhi::Operation::Bake) == (uint32_t)GpuBakeNvrhi::Operation::Bake)
 		config.bakeFlags = (omm::Gpu::BakeFlags)((uint32_t)config.bakeFlags | (uint32_t)omm::Gpu::BakeFlags::PerformBake);
 
+	if (params.enableStats)
+		config.bakeFlags = (omm::Gpu::BakeFlags)((uint32_t)config.bakeFlags | (uint32_t)omm::Gpu::BakeFlags::EnablePostDispatchInfoStats);
+
 	if (m_enableDebug)
 		config.bakeFlags = (omm::Gpu::BakeFlags)((uint32_t)config.bakeFlags | (uint32_t)omm::Gpu::BakeFlags::EnableNsightDebugMode);
-	config.bakeFlags = (omm::Gpu::BakeFlags)((uint32_t)config.bakeFlags | (uint32_t)omm::Gpu::BakeFlags::EnablePostBuildInfo);
 	
 	if (!params.enableSpecialIndices)
 		config.bakeFlags = (omm::Gpu::BakeFlags)((uint32_t)config.bakeFlags | (uint32_t)omm::Gpu::BakeFlags::DisableSpecialIndices);
@@ -633,6 +635,7 @@ omm::Gpu::DispatchConfigDesc GpuBakeNvrhiImpl::GetConfig(const GpuBakeNvrhi::Inp
 	
 	if (!params.enableLevelLineIntersection)
 		config.bakeFlags = (omm::Gpu::BakeFlags)((uint32_t)config.bakeFlags | (uint32_t)omm::Gpu::BakeFlags::DisableLevelLineIntersection);
+
 
 	if (params.enableNsightDebugMode)
 		config.bakeFlags = (omm::Gpu::BakeFlags)((uint32_t)config.bakeFlags | (uint32_t)omm::Gpu::BakeFlags::EnableNsightDebugMode);
@@ -697,7 +700,7 @@ void GpuBakeNvrhiImpl::GetPreDispatchInfo(const GpuBakeNvrhi::Input& params, Gpu
 	info.ommArrayBufferSize = preBuildInfo.outOmmArraySizeInBytes;
 	info.ommDescBufferSize = preBuildInfo.outOmmDescSizeInBytes;
 	info.ommDescArrayHistogramSize = preBuildInfo.outOmmArrayHistogramSizeInBytes;
-	info.ommPostBuildInfoBufferSize = preBuildInfo.outOmmPostBuildInfoSizeInBytes;
+	info.ommPostDispatchInfoBufferSize = preBuildInfo.outOmmPostDispatchInfoSizeInBytes;
 }
 
 void GpuBakeNvrhiImpl::Dispatch(
@@ -729,7 +732,7 @@ void GpuBakeNvrhiImpl::Clear()
 
 void GpuBakeNvrhiImpl::ReadPostBuildInfo(void* pData, size_t byteSize, GpuBakeNvrhi::PostBuildInfo& outPostBuildInfo)
 {
-	static_assert(sizeof(omm::Gpu::PostBakeInfo) == sizeof(GpuBakeNvrhi::PostBuildInfo));
+	static_assert(sizeof(omm::Gpu::PostDispatchInfo) == sizeof(GpuBakeNvrhi::PostBuildInfo));
 	assert(byteSize >= sizeof(GpuBakeNvrhi::PostBuildInfo));
 	memcpy(&outPostBuildInfo, pData, sizeof(GpuBakeNvrhi::PostBuildInfo));
 }
@@ -798,9 +801,9 @@ nvrhi::BufferHandle GpuBakeNvrhiImpl::GetBufferResource(
 		resourceHandle = output.ommIndexHistogramBuffer;
 		offsetInBytes = output.ommIndexHistogramBufferOffset;
 		break;
-	case omm::Gpu::ResourceType::OUT_POST_BAKE_INFO:
-		resourceHandle = output.ommPostBuildInfoBuffer;
-		offsetInBytes = output.ommPostBuildInfoBufferOffset;
+	case omm::Gpu::ResourceType::OUT_POST_DISPATCH_INFO:
+		resourceHandle = output.ommPostDispatchInfoBuffer;
+		offsetInBytes = output.ommPostDispatchInfoBufferOffset;
 		break;
 	case omm::Gpu::ResourceType::IN_INDEX_BUFFER:
 		resourceHandle = params.indexBuffer;

--- a/integration/omm-sdk-nvrhi/omm-sdk-nvrhi.cpp
+++ b/integration/omm-sdk-nvrhi/omm-sdk-nvrhi.cpp
@@ -636,7 +636,6 @@ omm::Gpu::DispatchConfigDesc GpuBakeNvrhiImpl::GetConfig(const GpuBakeNvrhi::Inp
 	if (!params.enableLevelLineIntersection)
 		config.bakeFlags = (omm::Gpu::BakeFlags)((uint32_t)config.bakeFlags | (uint32_t)omm::Gpu::BakeFlags::DisableLevelLineIntersection);
 
-
 	if (params.enableNsightDebugMode)
 		config.bakeFlags = (omm::Gpu::BakeFlags)((uint32_t)config.bakeFlags | (uint32_t)omm::Gpu::BakeFlags::EnableNsightDebugMode);
 

--- a/integration/omm-sdk-nvrhi/omm-sdk-nvrhi.h
+++ b/integration/omm-sdk-nvrhi/omm-sdk-nvrhi.h
@@ -64,6 +64,7 @@ namespace omm
 			nvrhi::rt::OpacityMicromapFormat	format = nvrhi::rt::OpacityMicromapFormat::OC1_4_State;
 			float								dynamicSubdivisionScale = 0.5f;
 			bool								minimalMemoryMode = false;
+			bool								enableStats = false;
 			bool								enableSpecialIndices = true;
 			bool								force32BitIndices = false;
 			bool								enableTexCoordDeduplication = true;
@@ -80,7 +81,7 @@ namespace omm
 			size_t			ommArrayBufferSize;
 			size_t			ommDescBufferSize;
 			size_t			ommDescArrayHistogramSize;
-			size_t			ommPostBuildInfoBufferSize;
+			size_t			ommPostDispatchInfoBufferSize;
 		};
 
 		struct Buffers
@@ -90,20 +91,26 @@ namespace omm
 			nvrhi::BufferHandle ommIndexBuffer;
 			nvrhi::BufferHandle ommDescArrayHistogramBuffer;
 			nvrhi::BufferHandle ommIndexHistogramBuffer;
-			nvrhi::BufferHandle ommPostBuildInfoBuffer;
+			nvrhi::BufferHandle ommPostDispatchInfoBuffer;
 
 			uint32_t ommArrayBufferOffset = 0;
 			uint32_t ommDescBufferOffset = 0;
 			uint32_t ommIndexBufferOffset = 0;
 			uint32_t ommDescArrayHistogramBufferOffset = 0;
 			uint32_t ommIndexHistogramBufferOffset = 0;
-			uint32_t ommPostBuildInfoBufferOffset = 0;
+			uint32_t ommPostDispatchInfoBufferOffset = 0;
 		};
 
 		struct PostBuildInfo
 		{
 			uint32_t ommArrayBufferSize;
 			uint32_t ommDescBufferSize;
+			uint32_t ommTotalOpaqueCount;
+			uint32_t ommTotalTransparentCount;
+			uint32_t ommTotalUnknownCount;
+			uint32_t ommTotalFullyOpaqueCount;
+			uint32_t ommTotalFullyTransparentCount;
+			uint32_t ommTotalFullyUnknownCount;
 		};
 
 		struct Stats

--- a/omm-sdk/include/omm.h
+++ b/omm-sdk/include/omm.h
@@ -908,17 +908,17 @@ typedef struct ommGpuPostDispatchInfo
 {
    uint32_t outOmmArraySizeInBytes;
    uint32_t outOmmDescSizeInBytes;
-   // Will be set if EnablePostDispatchInfoStats is set.
+   // Will be populated if EnablePostDispatchInfoStats is set.
    uint32_t outStatsTotalOpaqueCount;
-   // Will be set if EnablePostDispatchInfoStats is set.
+   // Will be populated if EnablePostDispatchInfoStats is set.
    uint32_t outStatsTotalTransparentCount;
-   // Will be set if EnablePostDispatchInfoStats is set.
+   // Will be populated if EnablePostDispatchInfoStats is set.
    uint32_t outStatsTotalUnknownCount;
-   // Will be set if EnablePostDispatchInfoStats is set.
+   // Will be populated if EnablePostDispatchInfoStats is set.
    uint32_t outStatsTotalFullyOpaqueCount;
-   // Will be set if EnablePostDispatchInfoStats is set.
+   // Will be populated if EnablePostDispatchInfoStats is set.
    uint32_t outStatsTotalFullyTransparentCount;
-   // Will be set if EnablePostDispatchInfoStats is set.
+   // Will be populated if EnablePostDispatchInfoStats is set.
    uint32_t outStatsTotalFullyStatsUnknownCount;
 } ommGpuPostDispatchInfo;
 

--- a/omm-sdk/include/omm.h
+++ b/omm-sdk/include/omm.h
@@ -521,9 +521,6 @@ typedef enum ommGpuBakeFlags
    // Either PerformSetup, PerformBake (or both simultaneously) must be set.
    ommGpuBakeFlags_Invalid                      = 0,
 
-   // Alias for (PerformSetup | PerformBake)
-   ommGpuBakeFlags_PerformSetupAndBake          = 3u,
-
    // (Default) OUT_OMM_DESC_ARRAY_HISTOGRAM, OUT_OMM_INDEX_HISTOGRAM, OUT_OMM_INDEX_BUFFER, OUT_OMM_DESC_ARRAY and
    // OUT_POST_DISPATCH_INFO will be updated.
    ommGpuBakeFlags_PerformSetup                 = 1u << 0,
@@ -534,6 +531,9 @@ typedef enum ommGpuBakeFlags
    // OUT_OMM_DESC_ARRAY must contain valid data from a prior PerformSetup pass.
    ommGpuBakeFlags_PerformBake                  = 1u << 1,
 
+   // Alias for (PerformSetup | PerformBake)
+   ommGpuBakeFlags_PerformSetupAndBake          = 3u,
+
    // Baking will only be done using compute shaders and no gfx involvement (drawIndirect or graphics PSOs). (Beta)
    // Will become default mode in the future.
    // + Useful for async workloads
@@ -541,27 +541,27 @@ typedef enum ommGpuBakeFlags
    // + Faster baking on low texel ratio to micro-triangle ratio (=rasterizing small triangles)
    // - May looses efficency when resampling large triangles (tail-effect). Potential mitigation is to batch multiple bake
    // jobs. However this is generally not a big problem.
-   ommGpuBakeFlags_ComputeOnly                  = 1u << 3,
+   ommGpuBakeFlags_ComputeOnly                  = 1u << 2,
 
    // Must be used together with EnablePostDispatchInfo. If set baking (PerformBake) will fill the stats data of
    // OUT_POST_DISPATCH_INFO.
-   ommGpuBakeFlags_EnablePostDispatchInfoStats  = 1u << 4,
+   ommGpuBakeFlags_EnablePostDispatchInfoStats  = 1u << 3,
 
    // Will disable the use of special indices in case the OMM-state is uniform. Only set this flag for debug purposes.
-   ommGpuBakeFlags_DisableSpecialIndices        = 1u << 5,
+   ommGpuBakeFlags_DisableSpecialIndices        = 1u << 4,
 
    // If texture coordinates are known to be unique tex cooord deduplication can be disabled to save processing time and free
    // up scratch memory.
-   ommGpuBakeFlags_DisableTexCoordDeduplication = 1u << 6,
+   ommGpuBakeFlags_DisableTexCoordDeduplication = 1u << 5,
 
    // Force 32-bit indices in OUT_OMM_INDEX_BUFFER
-   ommGpuBakeFlags_Force32BitIndices            = 1u << 7,
+   ommGpuBakeFlags_Force32BitIndices            = 1u << 6,
 
    // Use only for debug purposes. Level Line Intersection method is vastly superior in 4-state mode.
-   ommGpuBakeFlags_DisableLevelLineIntersection = 1u << 8,
+   ommGpuBakeFlags_DisableLevelLineIntersection = 1u << 7,
 
    // Slightly modifies the dispatch to aid frame capture debugging.
-   ommGpuBakeFlags_EnableNsightDebugMode        = 1u << 9,
+   ommGpuBakeFlags_EnableNsightDebugMode        = 1u << 8,
 } ommGpuBakeFlags;
 OMM_DEFINE_ENUM_FLAG_OPERATORS(ommGpuBakeFlags);
 

--- a/omm-sdk/include/omm.h
+++ b/omm-sdk/include/omm.h
@@ -528,8 +528,8 @@ typedef enum ommGpuBakeFlags
    // OUT_POST_DISPATCH_INFO will be updated.
    ommGpuBakeFlags_PerformSetup                 = 1u << 0,
 
-   // (Default) OUT_OMM_INDEX_HISTOGRAM, OUT_OMM_INDEX_BUFFER, OUT_OMM_ARRAY_DATA will be written to. If special indices are
-   // detected OUT_OMM_INDEX_BUFFER may also be modified.
+   // (Default) OUT_OMM_INDEX_HISTOGRAM, OUT_OMM_INDEX_BUFFER, OUT_OMM_ARRAY_DATA and OUT_POST_DISPATCH_INFO (if stats
+   // enabled) will be updated. will be written to. If special indices are detected OUT_OMM_INDEX_BUFFER may also be modified.
    // If PerformBuild is not used with this flag, OUT_OMM_DESC_ARRAY_HISTOGRAM, OUT_OMM_INDEX_HISTOGRAM, OUT_OMM_INDEX_BUFFER,
    // OUT_OMM_DESC_ARRAY must contain valid data from a prior PerformSetup pass.
    ommGpuBakeFlags_PerformBake                  = 1u << 1,

--- a/omm-sdk/include/omm.hpp
+++ b/omm-sdk/include/omm.hpp
@@ -433,8 +433,8 @@ namespace omm
          // OUT_POST_DISPATCH_INFO will be updated.
          PerformSetup                 = 1u << 0,
 
-         // (Default) OUT_OMM_INDEX_HISTOGRAM, OUT_OMM_INDEX_BUFFER, OUT_OMM_ARRAY_DATA will be written to. If special indices are
-         // detected OUT_OMM_INDEX_BUFFER may also be modified.
+         // (Default) OUT_OMM_INDEX_HISTOGRAM, OUT_OMM_INDEX_BUFFER, OUT_OMM_ARRAY_DATA and OUT_POST_DISPATCH_INFO (if stats
+         // enabled) will be updated. will be written to. If special indices are detected OUT_OMM_INDEX_BUFFER may also be modified.
          // If PerformBuild is not used with this flag, OUT_OMM_DESC_ARRAY_HISTOGRAM, OUT_OMM_INDEX_HISTOGRAM, OUT_OMM_INDEX_BUFFER,
          // OUT_OMM_DESC_ARRAY must contain valid data from a prior PerformSetup pass.
          PerformBake                  = 1u << 1,

--- a/omm-sdk/include/omm.hpp
+++ b/omm-sdk/include/omm.hpp
@@ -763,17 +763,17 @@ namespace omm
       {
          uint32_t outOmmArraySizeInBytes;
          uint32_t outOmmDescSizeInBytes;
-         // Will be set if EnablePostDispatchInfoStats is set.
+         // Will be populated if EnablePostDispatchInfoStats is set.
          uint32_t outStatsTotalOpaqueCount;
-         // Will be set if EnablePostDispatchInfoStats is set.
+         // Will be populated if EnablePostDispatchInfoStats is set.
          uint32_t outStatsTotalTransparentCount;
-         // Will be set if EnablePostDispatchInfoStats is set.
+         // Will be populated if EnablePostDispatchInfoStats is set.
          uint32_t outStatsTotalUnknownCount;
-         // Will be set if EnablePostDispatchInfoStats is set.
+         // Will be populated if EnablePostDispatchInfoStats is set.
          uint32_t outStatsTotalFullyOpaqueCount;
-         // Will be set if EnablePostDispatchInfoStats is set.
+         // Will be populated if EnablePostDispatchInfoStats is set.
          uint32_t outStatsTotalFullyTransparentCount;
-         // Will be set if EnablePostDispatchInfoStats is set.
+         // Will be populated if EnablePostDispatchInfoStats is set.
          uint32_t outStatsTotalFullyStatsUnknownCount;
       };
 

--- a/omm-sdk/include/omm.hpp
+++ b/omm-sdk/include/omm.hpp
@@ -426,9 +426,6 @@ namespace omm
          // Either PerformSetup, PerformBake (or both simultaneously) must be set.
          Invalid                      = 0,
 
-         // Alias for (PerformSetup | PerformBake)
-         PerformSetupAndBake          = 3u,
-
          // (Default) OUT_OMM_DESC_ARRAY_HISTOGRAM, OUT_OMM_INDEX_HISTOGRAM, OUT_OMM_INDEX_BUFFER, OUT_OMM_DESC_ARRAY and
          // OUT_POST_DISPATCH_INFO will be updated.
          PerformSetup                 = 1u << 0,
@@ -439,6 +436,9 @@ namespace omm
          // OUT_OMM_DESC_ARRAY must contain valid data from a prior PerformSetup pass.
          PerformBake                  = 1u << 1,
 
+         // Alias for (PerformSetup | PerformBake)
+         PerformSetupAndBake          = 3u,
+
          // Baking will only be done using compute shaders and no gfx involvement (drawIndirect or graphics PSOs). (Beta)
          // Will become default mode in the future.
          // + Useful for async workloads
@@ -446,27 +446,27 @@ namespace omm
          // + Faster baking on low texel ratio to micro-triangle ratio (=rasterizing small triangles)
          // - May looses efficency when resampling large triangles (tail-effect). Potential mitigation is to batch multiple bake
          // jobs. However this is generally not a big problem.
-         ComputeOnly                  = 1u << 3,
+         ComputeOnly                  = 1u << 2,
 
          // Must be used together with EnablePostDispatchInfo. If set baking (PerformBake) will fill the stats data of
          // OUT_POST_DISPATCH_INFO.
-         EnablePostDispatchInfoStats  = 1u << 4,
+         EnablePostDispatchInfoStats  = 1u << 3,
 
          // Will disable the use of special indices in case the OMM-state is uniform. Only set this flag for debug purposes.
-         DisableSpecialIndices        = 1u << 5,
+         DisableSpecialIndices        = 1u << 4,
 
          // If texture coordinates are known to be unique tex cooord deduplication can be disabled to save processing time and free
          // up scratch memory.
-         DisableTexCoordDeduplication = 1u << 6,
+         DisableTexCoordDeduplication = 1u << 5,
 
          // Force 32-bit indices in OUT_OMM_INDEX_BUFFER
-         Force32BitIndices            = 1u << 7,
+         Force32BitIndices            = 1u << 6,
 
          // Use only for debug purposes. Level Line Intersection method is vastly superior in 4-state mode.
-         DisableLevelLineIntersection = 1u << 8,
+         DisableLevelLineIntersection = 1u << 7,
 
          // Slightly modifies the dispatch to aid frame capture debugging.
-         EnableNsightDebugMode        = 1u << 9,
+         EnableNsightDebugMode        = 1u << 8,
       };
       OMM_DEFINE_ENUM_FLAG_OPERATORS(BakeFlags);
 

--- a/omm-sdk/scripts/omm.json
+++ b/omm-sdk/scripts/omm.json
@@ -2012,32 +2012,32 @@
             {
                 "type": "uint32_t",
                 "name": "outStatsTotalOpaqueCount",
-                "comment": "Will be set if EnablePostDispatchInfoStats is set."
+                "comment": "Will be populated if EnablePostDispatchInfoStats is set."
             },
             {
                 "type": "uint32_t",
                 "name": "outStatsTotalTransparentCount",
-                "comment": "Will be set if EnablePostDispatchInfoStats is set."
+                "comment": "Will be populated if EnablePostDispatchInfoStats is set."
             },
             {
                 "type": "uint32_t",
                 "name": "outStatsTotalUnknownCount",
-                "comment": "Will be set if EnablePostDispatchInfoStats is set."
+                "comment": "Will be populated if EnablePostDispatchInfoStats is set."
             },
             {
                 "type": "uint32_t",
                 "name": "outStatsTotalFullyOpaqueCount",
-                "comment": "Will be set if EnablePostDispatchInfoStats is set."
+                "comment": "Will be populated if EnablePostDispatchInfoStats is set."
             },
             {
                 "type": "uint32_t",
                 "name": "outStatsTotalFullyTransparentCount",
-                "comment": "Will be set if EnablePostDispatchInfoStats is set."
+                "comment": "Will be populated if EnablePostDispatchInfoStats is set."
             },
             {
                 "type": "uint32_t",
                 "name": "outStatsTotalFullyStatsUnknownCount",
-                "comment": "Will be set if EnablePostDispatchInfoStats is set."
+                "comment": "Will be populated if EnablePostDispatchInfoStats is set."
             }
         ]
     },

--- a/omm-sdk/scripts/omm.json
+++ b/omm-sdk/scripts/omm.json
@@ -1135,7 +1135,7 @@
             {
                 "name": "PerformBake",
                 "value": "1u << 1",
-                "comment": "(Default) OUT_OMM_INDEX_HISTOGRAM, OUT_OMM_INDEX_BUFFER, OUT_OMM_ARRAY_DATA will be written to. If special indices are detected OUT_OMM_INDEX_BUFFER may also be modified.\nIf PerformBuild is not used with this flag, OUT_OMM_DESC_ARRAY_HISTOGRAM, OUT_OMM_INDEX_HISTOGRAM, OUT_OMM_INDEX_BUFFER, OUT_OMM_DESC_ARRAY must contain valid data from a prior PerformSetup pass."
+                "comment": "(Default) OUT_OMM_INDEX_HISTOGRAM, OUT_OMM_INDEX_BUFFER, OUT_OMM_ARRAY_DATA and OUT_POST_DISPATCH_INFO (if stats enabled) will be updated. will be written to. If special indices are detected OUT_OMM_INDEX_BUFFER may also be modified.\nIf PerformBuild is not used with this flag, OUT_OMM_DESC_ARRAY_HISTOGRAM, OUT_OMM_INDEX_HISTOGRAM, OUT_OMM_INDEX_BUFFER, OUT_OMM_DESC_ARRAY must contain valid data from a prior PerformSetup pass."
             },
             {
                 "name": "ComputeOnly",

--- a/omm-sdk/scripts/omm.json
+++ b/omm-sdk/scripts/omm.json
@@ -1123,11 +1123,6 @@
                 "comment": "Either PerformSetup, PerformBake (or both simultaneously) must be set."
             },
             {
-                "name": "PerformSetupAndBake",
-                "value": "3u",
-                "comment": "Alias for (PerformSetup | PerformBake)"
-            },
-            {
                 "name": "PerformSetup",
                 "value": "1u << 0",
                 "comment": "(Default) OUT_OMM_DESC_ARRAY_HISTOGRAM, OUT_OMM_INDEX_HISTOGRAM, OUT_OMM_INDEX_BUFFER, OUT_OMM_DESC_ARRAY and OUT_POST_DISPATCH_INFO will be updated."
@@ -1138,38 +1133,43 @@
                 "comment": "(Default) OUT_OMM_INDEX_HISTOGRAM, OUT_OMM_INDEX_BUFFER, OUT_OMM_ARRAY_DATA and OUT_POST_DISPATCH_INFO (if stats enabled) will be updated. will be written to. If special indices are detected OUT_OMM_INDEX_BUFFER may also be modified.\nIf PerformBuild is not used with this flag, OUT_OMM_DESC_ARRAY_HISTOGRAM, OUT_OMM_INDEX_HISTOGRAM, OUT_OMM_INDEX_BUFFER, OUT_OMM_DESC_ARRAY must contain valid data from a prior PerformSetup pass."
             },
             {
+                "name": "PerformSetupAndBake",
+                "value": "3u",
+                "comment": "Alias for (PerformSetup | PerformBake)"
+            },
+            {
                 "name": "ComputeOnly",
-                "value": "1u << 3",
+                "value": "1u << 2",
                 "comment": "Baking will only be done using compute shaders and no gfx involvement (drawIndirect or graphics PSOs). (Beta)\nWill become default mode in the future.\n+ Useful for async workloads\n+ Less memory hungry\n+ Faster baking on low texel ratio to micro-triangle ratio (=rasterizing small triangles)\n- May looses efficency when resampling large triangles (tail-effect). Potential mitigation is to batch multiple bake jobs. However this is generally not a big problem."
             },
             {
                 "name": "EnablePostDispatchInfoStats",
-                "value": "1u << 4",
+                "value": "1u << 3",
                 "comment": "Must be used together with EnablePostDispatchInfo. If set baking (PerformBake) will fill the stats data of OUT_POST_DISPATCH_INFO."
             },
             {
                 "name": "DisableSpecialIndices",
-                "value": "1u << 5",
+                "value": "1u << 4",
                 "comment": "Will disable the use of special indices in case the OMM-state is uniform. Only set this flag for debug purposes."
             },
             {
                 "name": "DisableTexCoordDeduplication",
-                "value": "1u << 6",
+                "value": "1u << 5",
                 "comment": "If texture coordinates are known to be unique tex cooord deduplication can be disabled to save processing time and free up scratch memory."
             },
             {
                 "name": "Force32BitIndices",
-                "value": "1u << 7",
+                "value": "1u << 6",
                 "comment": "Force 32-bit indices in OUT_OMM_INDEX_BUFFER"
             },
             {
                 "name": "DisableLevelLineIntersection",
-                "value": "1u << 8",
+                "value": "1u << 7",
                 "comment": "Use only for debug purposes. Level Line Intersection method is vastly superior in 4-state mode."
             },
             {
                 "name": "EnableNsightDebugMode",
-                "value": "1u << 9",
+                "value": "1u << 8",
                 "comment": "Slightly modifies the dispatch to aid frame capture debugging."
             }
         ]

--- a/omm-sdk/scripts/omm.json
+++ b/omm-sdk/scripts/omm.json
@@ -947,8 +947,8 @@
                 "comment": "Used directly as argument for OMM build in DX/VK. (Read back to CPU to query memory requirements during OMM Blas build)"
             },
             {
-                "name": "OUT_POST_BAKE_INFO",
-                "comment": "(Optional, enabled if EnablePostBuildInfo is set). Read back the PostBakeInfo struct containing the actual sizes of ARRAY_DATA and DESC_ARRAY."
+                "name": "OUT_POST_DISPATCH_INFO",
+                "comment": "Read back the PostDispatchInfo struct containing the actual sizes of ARRAY_DATA and DESC_ARRAY."
             },
             {
                 "name": "TRANSIENT_POOL_BUFFER",
@@ -1123,9 +1123,14 @@
                 "comment": "Either PerformSetup, PerformBake (or both simultaneously) must be set."
             },
             {
+                "name": "PerformSetupAndBake",
+                "value": "3u",
+                "comment": "Alias for (PerformSetup | PerformBake)"
+            },
+            {
                 "name": "PerformSetup",
                 "value": "1u << 0",
-                "comment": "(Default) OUT_OMM_DESC_ARRAY_HISTOGRAM, OUT_OMM_INDEX_HISTOGRAM, OUT_OMM_INDEX_BUFFER, OUT_OMM_DESC_ARRAY and (optionally) OUT_POST_BAKE_INFO will be updated."
+                "comment": "(Default) OUT_OMM_DESC_ARRAY_HISTOGRAM, OUT_OMM_INDEX_HISTOGRAM, OUT_OMM_INDEX_BUFFER, OUT_OMM_DESC_ARRAY and OUT_POST_DISPATCH_INFO will be updated."
             },
             {
                 "name": "PerformBake",
@@ -1133,43 +1138,38 @@
                 "comment": "(Default) OUT_OMM_INDEX_HISTOGRAM, OUT_OMM_INDEX_BUFFER, OUT_OMM_ARRAY_DATA will be written to. If special indices are detected OUT_OMM_INDEX_BUFFER may also be modified.\nIf PerformBuild is not used with this flag, OUT_OMM_DESC_ARRAY_HISTOGRAM, OUT_OMM_INDEX_HISTOGRAM, OUT_OMM_INDEX_BUFFER, OUT_OMM_DESC_ARRAY must contain valid data from a prior PerformSetup pass."
             },
             {
-                "name": "PerformSetupAndBake",
-                "value": "3u",
-                "comment": "Alias for (PerformSetup | PerformBake)"
-            },
-            {
                 "name": "ComputeOnly",
-                "value": "1u << 2",
+                "value": "1u << 3",
                 "comment": "Baking will only be done using compute shaders and no gfx involvement (drawIndirect or graphics PSOs). (Beta)\nWill become default mode in the future.\n+ Useful for async workloads\n+ Less memory hungry\n+ Faster baking on low texel ratio to micro-triangle ratio (=rasterizing small triangles)\n- May looses efficency when resampling large triangles (tail-effect). Potential mitigation is to batch multiple bake jobs. However this is generally not a big problem."
             },
             {
-                "name": "EnablePostBuildInfo",
-                "value": "1u << 3",
-                "comment": "Baking will also output post build info. (OUT_POST_BUILD_INFO)."
+                "name": "EnablePostDispatchInfoStats",
+                "value": "1u << 4",
+                "comment": "Must be used together with EnablePostDispatchInfo. If set baking (PerformBake) will fill the stats data of OUT_POST_DISPATCH_INFO."
             },
             {
                 "name": "DisableSpecialIndices",
-                "value": "1u << 4",
+                "value": "1u << 5",
                 "comment": "Will disable the use of special indices in case the OMM-state is uniform. Only set this flag for debug purposes."
             },
             {
                 "name": "DisableTexCoordDeduplication",
-                "value": "1u << 5",
+                "value": "1u << 6",
                 "comment": "If texture coordinates are known to be unique tex cooord deduplication can be disabled to save processing time and free up scratch memory."
             },
             {
                 "name": "Force32BitIndices",
-                "value": "1u << 6",
+                "value": "1u << 7",
                 "comment": "Force 32-bit indices in OUT_OMM_INDEX_BUFFER"
             },
             {
                 "name": "DisableLevelLineIntersection",
-                "value": "1u << 7",
+                "value": "1u << 8",
                 "comment": "Use only for debug purposes. Level Line Intersection method is vastly superior in 4-state mode."
             },
             {
                 "name": "EnableNsightDebugMode",
-                "value": "1u << 8",
+                "value": "1u << 9",
                 "comment": "Slightly modifies the dispatch to aid frame capture debugging."
             }
         ]
@@ -1846,7 +1846,7 @@
                 "type": "uint32_t",
                 "name": "maxOutOmmArraySize",
                 "value": "0xFFFFFFFF",
-                "comment": "The SDK will try to limit the omm array size of PreDispatchInfo::outOmmArraySizeInBytes and PostBakeInfo::outOmmArraySizeInBytes.\nCurrently a greedy algorithm is implemented with a first come-first serve order.\nThe SDK may (or may not) apply more sophisticated heuristics in the future.\nIf no memory is available to allocate an OMM Array Block the state will default to Unknown Opaque (ignoring any bake flags do disable special indices)."
+                "comment": "The SDK will try to limit the omm array size of PreDispatchInfo::outOmmArraySizeInBytes and PostDispatchInfo::outOmmArraySizeInBytes.\nCurrently a greedy algorithm is implemented with a first come-first serve order.\nThe SDK may (or may not) apply more sophisticated heuristics in the future.\nIf no memory is available to allocate an OMM Array Block the state will default to Unknown Opaque (ignoring any bake flags do disable special indices)."
             },
             {
                 "type": "ScratchMemoryBudget",
@@ -1954,9 +1954,9 @@
             },
             {
                 "type": "uint32_t",
-                "name": "outOmmPostBuildInfoSizeInBytes",
+                "name": "outOmmPostDispatchInfoSizeInBytes",
                 "value": "0xFFFFFFFF",
-                "comment": "Min required size of OUT_POST_BUILD_INFO"
+                "comment": "Min required size of OUT_POST_DISPATCH_INFO"
             },
             {
                 "type": "uint32_t",
@@ -1996,10 +1996,10 @@
         ]
     },
 
-    "PostBakeInfo": {
+    "PostDispatchInfo": {
         "type": "struct",
-        "name": "PostBakeInfo",
-        "comment": "Format of OUT_POST_BAKE_INFO",
+        "name": "PostDispatchInfo",
+        "comment": "Format of OUT_POST_DISPATCH_INFO",
         "members": [
             {
                 "type": "uint32_t",
@@ -2008,6 +2008,36 @@
             {
                 "type": "uint32_t",
                 "name": "outOmmDescSizeInBytes"
+            },
+            {
+                "type": "uint32_t",
+                "name": "outStatsTotalOpaqueCount",
+                "comment": "Will be set if EnablePostDispatchInfoStats is set."
+            },
+            {
+                "type": "uint32_t",
+                "name": "outStatsTotalTransparentCount",
+                "comment": "Will be set if EnablePostDispatchInfoStats is set."
+            },
+            {
+                "type": "uint32_t",
+                "name": "outStatsTotalUnknownCount",
+                "comment": "Will be set if EnablePostDispatchInfoStats is set."
+            },
+            {
+                "type": "uint32_t",
+                "name": "outStatsTotalFullyOpaqueCount",
+                "comment": "Will be set if EnablePostDispatchInfoStats is set."
+            },
+            {
+                "type": "uint32_t",
+                "name": "outStatsTotalFullyTransparentCount",
+                "comment": "Will be set if EnablePostDispatchInfoStats is set."
+            },
+            {
+                "type": "uint32_t",
+                "name": "outStatsTotalFullyStatsUnknownCount",
+                "comment": "Will be set if EnablePostDispatchInfoStats is set."
             }
         ]
     },
@@ -2384,7 +2414,7 @@
             "PreDispatchInfo",
             "DispatchConfigDesc",
             "PipelineInfoDesc",
-            "PostBakeInfo",
+            "PostDispatchInfo",
             "DispatchChain",
             "fnGetStaticResourceData",
             "fnCreatePipeline",

--- a/omm-sdk/shaders/omm.hlsli
+++ b/omm-sdk/shaders/omm.hlsli
@@ -38,7 +38,7 @@ enum class SpecialIndex : int {
 	FullyUnknownOpaque       = -4,
 };
 
-OpacityState GetOpacityState(uint numOpaque, uint numTransparent)
+OpacityState _getOpacityStateInternal(uint numOpaque, uint numTransparent)
 {
 	if (numOpaque == 0)
 	{
@@ -56,6 +56,14 @@ OpacityState GetOpacityState(uint numOpaque, uint numTransparent)
 	{
 		return OpacityState::UnknownOpaque;
 	}
+}
+
+OpacityState GetOpacityState(uint numOpaque, uint numTransparent, OMMFormat ommFormat)
+{
+	OpacityState opacityState = _getOpacityStateInternal(numOpaque, numTransparent);
+	if (ommFormat == OMMFormat::OC1_2)
+		return (OpacityState)((uint)opacityState & 1u);
+	return opacityState;
 }
 
 float3 GetDebugColorForState(OpacityState state)

--- a/omm-sdk/shaders/omm_desc_patch.cs.hlsl
+++ b/omm-sdk/shaders/omm_desc_patch.cs.hlsl
@@ -89,12 +89,12 @@ void UpdatePostBuildInfo(PrimitiveHistogram h)
 		const SpecialIndex specialIndex = h.GetSpecialIndex();
 
 		if (specialIndex == SpecialIndex::FullyOpaque)
-			u_postBuildInfo.InterlockedAdd(4 * kOffsetTotalFullyOpaque, h.counts.x);
+			u_postBuildInfo.InterlockedAdd(4 * kOffsetTotalFullyOpaque, 1);
 		if (specialIndex == SpecialIndex::FullyTransparent)
-			u_postBuildInfo.InterlockedAdd(4 * kOffsetTotalFullyTransparent, h.counts.y);
+			u_postBuildInfo.InterlockedAdd(4 * kOffsetTotalFullyTransparent, 1);
 		if (specialIndex == SpecialIndex::FullyUnknownTransparent ||
 			specialIndex == SpecialIndex::FullyUnknownOpaque)
-			u_postBuildInfo.InterlockedAdd(4 * kOffsetTotalFullyUnknown, h.counts.z);
+			u_postBuildInfo.InterlockedAdd(4 * kOffsetTotalFullyUnknown, 1);
 	}
 	else
 	{

--- a/omm-sdk/shaders/omm_desc_patch.cs.hlsl
+++ b/omm-sdk/shaders/omm_desc_patch.cs.hlsl
@@ -84,7 +84,7 @@ void UpdatePostBuildInfo(PrimitiveHistogram h)
 	const uint kOffsetTotalFullyTransparent = 6;
 	const uint kOffsetTotalFullyUnknown = 7;
 
-	if (h.IsSpecialIndex())
+	if (g_GlobalConstants.EnableSpecialIndices && h.IsSpecialIndex())
 	{
 		const SpecialIndex specialIndex = h.GetSpecialIndex();
 

--- a/omm-sdk/shaders/omm_desc_patch.cs.resources.hlsli
+++ b/omm-sdk/shaders/omm_desc_patch.cs.resources.hlsli
@@ -14,7 +14,8 @@ license agreement from NVIDIA CORPORATION is strictly prohibited.
 
 #define OMM_DECLARE_OUTPUT_RESOURCES \
     OMM_OUTPUT_RESOURCE( RWByteAddressBuffer, u_ommIndexHistogramBuffer, u, 0 ) \
-    OMM_OUTPUT_RESOURCE( RWByteAddressBuffer, u_heap0, u, 1 ) \
+    OMM_OUTPUT_RESOURCE( RWByteAddressBuffer, u_postBuildInfo, u, 1 ) \
+    OMM_OUTPUT_RESOURCE( RWByteAddressBuffer, u_heap0, u, 2 ) \
 
 #define OMM_DECLARE_SUBRESOURCES \
     OMM_SUBRESOURCE(RWByteAddressBuffer, TempOmmIndexBuffer, u_heap0) \

--- a/omm-sdk/shaders/omm_global_cb.hlsli
+++ b/omm-sdk/shaders/omm_global_cb.hlsli
@@ -39,7 +39,7 @@ OMM_CONSTANTS_START(GlobalConstants)							\
 	OMM_CONSTANT(uint, AlphaTextureChannel)						\
 	OMM_CONSTANT(uint, FilterType) /* TextureFilterMode */ 		\
 	OMM_CONSTANT(uint, EnableLevelLine)							\
-	OMM_CONSTANT(uint, Pad1)									\
+	OMM_CONSTANT(uint, EnablePostDispatchInfoStats)				\
 																\
 	OMM_CONSTANT(float2, TexSize)								\
 	OMM_CONSTANT(float2, InvTexSize)							\

--- a/omm-sdk/shaders/omm_post_build_info.cs.hlsl
+++ b/omm-sdk/shaders/omm_post_build_info.cs.hlsl
@@ -33,4 +33,10 @@ void main(uint3 tid : SV_DispatchThreadID)
 
 	u_postBuildInfo.Store(0, min(ommArrayByteSize, g_GlobalConstants.MaxOutOmmArraySize));
 	u_postBuildInfo.Store(4, ommDescByteSize);
+	u_postBuildInfo.Store(8, 0);
+	u_postBuildInfo.Store(12, 0);
+	u_postBuildInfo.Store(16, 0);
+	u_postBuildInfo.Store(20, 0);
+	u_postBuildInfo.Store(24, 0);
+	u_postBuildInfo.Store(28, 0);
 }

--- a/omm-sdk/shaders/omm_rasterize.vs.hlsl
+++ b/omm-sdk/shaders/omm_rasterize.vs.hlsl
@@ -42,7 +42,7 @@ void main(
 	const float alpha			= color[g_GlobalConstants.AlphaTextureChannel];
 
 	const uint isOpaque			= g_GlobalConstants.AlphaCutoff < alpha;
-	const OpacityState vmState	= GetOpacityState(isOpaque, !isOpaque);
+	const OpacityState vmState	= GetOpacityState(isOpaque, !isOpaque, OMMFormat::OC1_4);
 
 	o_primitiveIndex		= i_primitiveIndex;
 	o_texCoord				= texCoord;

--- a/omm-sdk/shaders/omm_rasterize_debug.ps.hlsl
+++ b/omm-sdk/shaders/omm_rasterize_debug.ps.hlsl
@@ -36,7 +36,7 @@ void main(
 
 	const uint numOpaque		= OMM_SUBRESOURCE_LOAD(BakeResultBuffer, microTriOffset);
 	const uint numTrans			= OMM_SUBRESOURCE_LOAD(BakeResultBuffer, microTriOffset + 4);
-	const OpacityState state	= GetOpacityState(numOpaque, numTrans);
+	const OpacityState state	= GetOpacityState(numOpaque, numTrans, OMMFormat::OC1_4);
 	const float3 debugColor		= GetDebugColorForState(state);
 
 	const float2 texCoord		= raster::PS_SV_Position_to_TexCoord(i_svPosition);

--- a/omm-sdk/src/bake_gpu_impl.cpp
+++ b/omm-sdk/src/bake_gpu_impl.cpp
@@ -432,7 +432,6 @@ ommResult PipelineImpl::GetPreDispatchInfo(const ommGpuDispatchConfigDesc& confi
     const bool computeOnly = (((uint32_t)config.bakeFlags & (uint32_t)ommGpuBakeFlags_ComputeOnly) == (uint32_t)ommGpuBakeFlags_ComputeOnly);
     const bool enableTexCoordDedup = ((uint32_t)config.bakeFlags & (uint32_t)ommGpuBakeFlags_DisableTexCoordDeduplication) == 0;
     const bool enableSpecialIndices = ((uint32_t)config.bakeFlags & (uint32_t)ommGpuBakeFlags_DisableSpecialIndices) != (uint32_t)ommGpuBakeFlags_DisableSpecialIndices;
-    const bool is2State = config.globalFormat == ommFormat_OC1_2_State;
 
     const uint32_t primitiveCount = config.indexCount / 3;
     const uint32_t defaultAlignment = 128;
@@ -917,6 +916,7 @@ ommResult PipelineImpl::GetDispatchDesc(const ommGpuDispatchConfigDesc& config, 
                 });
         }
 
+        if (doSetup)
         {
             SCOPED_LABEL("PostBuildInfo");
 
@@ -1091,6 +1091,7 @@ ommResult PipelineImpl::GetDispatchDesc(const ommGpuDispatchConfigDesc& config, 
             }
         }
 
+        if (doSetup)
         {
             SCOPED_LABEL("PostBuildInfo");
 

--- a/tests/test_omm_bake_gpu.cpp
+++ b/tests/test_omm_bake_gpu.cpp
@@ -394,9 +394,13 @@ namespace {
 				EXPECT_EQ(postBuildInfo.ommTotalOpaqueCount, stats.totalOpaque);
 				EXPECT_EQ(postBuildInfo.ommTotalTransparentCount, stats.totalTransparent);
 				EXPECT_EQ(postBuildInfo.ommTotalUnknownCount, totalUnknown);
-				EXPECT_EQ(postBuildInfo.ommTotalFullyOpaqueCount, stats.totalFullyOpaque);
-				EXPECT_EQ(postBuildInfo.ommTotalFullyTransparentCount, stats.totalFullyTransparent);
-				EXPECT_EQ(postBuildInfo.ommTotalFullyUnknownCount, totalFullyUnknown);
+
+				if (p.maxOutOmmArraySize == 0xFFFFFFFF)
+				{
+					EXPECT_EQ(postBuildInfo.ommTotalFullyOpaqueCount, stats.totalFullyOpaque);
+					EXPECT_EQ(postBuildInfo.ommTotalFullyTransparentCount, stats.totalFullyTransparent);
+					EXPECT_EQ(postBuildInfo.ommTotalFullyUnknownCount, totalFullyUnknown);
+				}
 			}
 			else
 			{
@@ -1224,40 +1228,45 @@ namespace {
 
 	INSTANTIATE_TEST_SUITE_P(OMMTestGPU, OMMBakeTestGPU, 
 		::testing::Values(	
-							   //TestSuiteConfig::None,
-							   //TestSuiteConfig::DisableSpecialIndices,
-							   //TestSuiteConfig::Force32BitIndices,
-							   //TestSuiteConfig::DisableTexCoordDeduplication,
-							   //TestSuiteConfig::RedChannel,
-							   //TestSuiteConfig::BlueChannel,
-							   //TestSuiteConfig::GreenChannel,
-							   //
-							   //TestSuiteConfig::SetupBeforeBuild,
-							   //TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::DisableSpecialIndices,
-							   //TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::Force32BitIndices,
-							   //TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::DisableTexCoordDeduplication,
-							   //TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::RedChannel,
-							   //TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::BlueChannel,
-							   //TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::GreenChannel,
+							    TestSuiteConfig::None,
+							    TestSuiteConfig::EnablePostBuildInfoStats,
+							    TestSuiteConfig::DisableSpecialIndices,
+							    TestSuiteConfig::DisableSpecialIndices | TestSuiteConfig::EnablePostBuildInfoStats,
+							    TestSuiteConfig::Force32BitIndices,
+							    TestSuiteConfig::DisableTexCoordDeduplication,
+							    TestSuiteConfig::RedChannel,
+							    TestSuiteConfig::BlueChannel,
+							    TestSuiteConfig::GreenChannel,
+							    
+							    TestSuiteConfig::SetupBeforeBuild,
+								TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::EnablePostBuildInfoStats,
+							    TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::DisableSpecialIndices,
+							    TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::DisableSpecialIndices | TestSuiteConfig::EnablePostBuildInfoStats,
+							    TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::Force32BitIndices,
+							    TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::DisableTexCoordDeduplication,
+							    TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::RedChannel,
+							    TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::BlueChannel,
+							    TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::GreenChannel,
 								
-							   //TestSuiteConfig::ComputeOnly
-							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::DisableSpecialIndices, 
-							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::Force32BitIndices,
-							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::DisableTexCoordDeduplication,
-							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::RedChannel,
-							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::BlueChannel,
-							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::GreenChannel,
-							   // 
-							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild,
-							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::DisableSpecialIndices,
-							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::Force32BitIndices,
-							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::DisableTexCoordDeduplication,
-							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::RedChannel,
-							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::BlueChannel,
-							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::GreenChannel
-
-								TestSuiteConfig::EnablePostBuildInfoStats,
-								TestSuiteConfig::ComputeOnly | TestSuiteConfig::EnablePostBuildInfoStats
+							    TestSuiteConfig::ComputeOnly,
+							    TestSuiteConfig::ComputeOnly | TestSuiteConfig::EnablePostBuildInfoStats,
+							    TestSuiteConfig::ComputeOnly | TestSuiteConfig::DisableSpecialIndices, 
+							    TestSuiteConfig::ComputeOnly | TestSuiteConfig::DisableSpecialIndices | TestSuiteConfig::EnablePostBuildInfoStats,
+							    TestSuiteConfig::ComputeOnly | TestSuiteConfig::Force32BitIndices,
+							    TestSuiteConfig::ComputeOnly | TestSuiteConfig::DisableTexCoordDeduplication,
+							    TestSuiteConfig::ComputeOnly | TestSuiteConfig::RedChannel,
+							    TestSuiteConfig::ComputeOnly | TestSuiteConfig::BlueChannel,
+							    TestSuiteConfig::ComputeOnly | TestSuiteConfig::GreenChannel,
+							    
+							    TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild,
+							    TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::EnablePostBuildInfoStats,
+							    TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::DisableSpecialIndices,
+							    TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::DisableSpecialIndices | TestSuiteConfig::EnablePostBuildInfoStats,
+							    TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::Force32BitIndices,
+							    TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::DisableTexCoordDeduplication,
+							    TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::RedChannel,
+							    TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::BlueChannel,
+							    TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::GreenChannel
 						));
 
 }  // namespace

--- a/tests/test_omm_bake_gpu.cpp
+++ b/tests/test_omm_bake_gpu.cpp
@@ -35,6 +35,7 @@ namespace {
 		GreenChannel					= 1u << 5,
 		BlueChannel						= 1u << 6,
 		SetupBeforeBuild				= 1u << 7,
+		EnablePostBuildInfoStats		= 1u << 8,
 	};
 
 	class OMMBakeTestGPU : public ::testing::TestWithParam<TestSuiteConfig> {
@@ -57,6 +58,7 @@ namespace {
 
 		bool SetupBeforeBuild() const { return (GetParam() & TestSuiteConfig::SetupBeforeBuild) == TestSuiteConfig::SetupBeforeBuild; }
 		bool ComputeOnly() const { return (GetParam() & TestSuiteConfig::ComputeOnly) == TestSuiteConfig::ComputeOnly; }
+		bool EnablePostBuildInfoStats() const { return (GetParam() & TestSuiteConfig::EnablePostBuildInfoStats) == TestSuiteConfig::EnablePostBuildInfoStats; }
 		bool EnableSpecialIndices() const { return (GetParam() & TestSuiteConfig::DisableSpecialIndices) != TestSuiteConfig::DisableSpecialIndices; }
 		bool Force32BitIndices() const { return (GetParam() & TestSuiteConfig::Force32BitIndices) == TestSuiteConfig::Force32BitIndices; }
 		bool EnableTexCoordDeduplication() const { return (GetParam() & TestSuiteConfig::DisableTexCoordDeduplication) != TestSuiteConfig::DisableTexCoordDeduplication; }
@@ -168,6 +170,7 @@ namespace {
 			input.maxSubdivisionLevel = p.subdivisionLevel;
 			input.format = p.format == omm::Format::OC1_2_State ? nvrhi::rt::OpacityMicromapFormat::OC1_2_State : nvrhi::rt::OpacityMicromapFormat::OC1_4_State;
 			input.dynamicSubdivisionScale = 0.f;
+			input.enableStats = EnablePostBuildInfoStats();
 			input.enableSpecialIndices = EnableSpecialIndices();
 			input.force32BitIndices = Force32BitIndices();
 			input.enableTexCoordDeduplication = EnableTexCoordDeduplication();
@@ -183,7 +186,7 @@ namespace {
 				void* pData = m_device->mapBuffer(buffer, nvrhi::CpuAccessMode::Read);
 				assert(pData);
 				size_t byteSize = size == 0xFFFFFFFF ? buffer->getDesc().byteSize : size;
-				assert(size <= buffer->getDesc().byteSize);
+				assert(byteSize <= buffer->getDesc().byteSize);
 				data.resize(byteSize);
 				memcpy(data.data(), pData, byteSize);
 				m_device->unmapBuffer(buffer);
@@ -206,29 +209,29 @@ namespace {
 				res.ommIndexBuffer = m_device->createBuffer({ .byteSize = info.ommIndexBufferSize, .debugName = "omIndexBuffer", .canHaveUAVs = true, .canHaveRawViews = true });
 				res.ommDescArrayHistogramBuffer = m_device->createBuffer({ .byteSize = info.ommDescArrayHistogramSize , .debugName = "omUsageDescBuffer" , .canHaveUAVs = true, .canHaveRawViews = true });
 				res.ommIndexHistogramBuffer = m_device->createBuffer({ .byteSize = info.ommIndexHistogramSize , .debugName = "ommIndexHistogramBuffer" , .canHaveUAVs = true, .canHaveRawViews = true });
-				res.ommPostBuildInfoBuffer = m_device->createBuffer({ .byteSize = info.ommPostBuildInfoBufferSize , .debugName = "ommPostBuildInfoBuffer" , .canHaveUAVs = true, .canHaveRawViews = true });
+				res.ommPostDispatchInfoBuffer = m_device->createBuffer({ .byteSize = info.ommPostDispatchInfoBufferSize , .debugName = "ommPostBuildInfoBuffer" , .canHaveUAVs = true, .canHaveRawViews = true });
 
 				m_commandList->beginTrackingBufferState(res.ommDescBuffer, nvrhi::ResourceStates::Common);
 				m_commandList->beginTrackingBufferState(res.ommIndexBuffer, nvrhi::ResourceStates::Common);
 				m_commandList->beginTrackingBufferState(res.ommDescArrayHistogramBuffer, nvrhi::ResourceStates::Common);
 				m_commandList->beginTrackingBufferState(res.ommIndexHistogramBuffer, nvrhi::ResourceStates::Common);
-				m_commandList->beginTrackingBufferState(res.ommPostBuildInfoBuffer, nvrhi::ResourceStates::Common);
+				m_commandList->beginTrackingBufferState(res.ommPostDispatchInfoBuffer, nvrhi::ResourceStates::Common);
 
 				omm::GpuBakeNvrhi::Buffers prePass;
 				prePass.ommDescBuffer = res.ommDescBuffer;
 				prePass.ommIndexBuffer = res.ommIndexBuffer;
 				prePass.ommDescArrayHistogramBuffer = res.ommDescArrayHistogramBuffer;
 				prePass.ommIndexHistogramBuffer = res.ommIndexHistogramBuffer;
-				prePass.ommPostBuildInfoBuffer = res.ommPostBuildInfoBuffer;
+				prePass.ommPostDispatchInfoBuffer = res.ommPostDispatchInfoBuffer;
 
 				bake.Dispatch(
 					m_commandList,
 					input,
 					prePass);
 
-				nvrhi::BufferHandle ommPostBuildInfoBufferReadback = m_device->createBuffer({ .byteSize = info.ommPostBuildInfoBufferSize , .debugName = "ommPostBuildInfoBufferReadback" , .cpuAccess = nvrhi::CpuAccessMode::Read });
+				nvrhi::BufferHandle ommPostBuildInfoBufferReadback = m_device->createBuffer({ .byteSize = info.ommPostDispatchInfoBufferSize , .debugName = "ommPostDispatchInfoBufferReadback" , .cpuAccess = nvrhi::CpuAccessMode::Read });
 				m_commandList->beginTrackingBufferState(ommPostBuildInfoBufferReadback, nvrhi::ResourceStates::Common);
-				m_commandList->copyBuffer(ommPostBuildInfoBufferReadback, 0, res.ommPostBuildInfoBuffer, 0, info.ommPostBuildInfoBufferSize);
+				m_commandList->copyBuffer(ommPostBuildInfoBufferReadback, 0, res.ommPostDispatchInfoBuffer, 0, info.ommPostDispatchInfoBufferSize);
 
 				m_commandList->close();
 
@@ -258,7 +261,7 @@ namespace {
 				m_commandList->beginTrackingBufferState(res.ommIndexBuffer, nvrhi::ResourceStates::Common);
 				m_commandList->beginTrackingBufferState(res.ommDescArrayHistogramBuffer, nvrhi::ResourceStates::Common);
 				m_commandList->beginTrackingBufferState(res.ommIndexHistogramBuffer, nvrhi::ResourceStates::Common);
-				m_commandList->beginTrackingBufferState(res.ommPostBuildInfoBuffer, nvrhi::ResourceStates::Common);
+				m_commandList->beginTrackingBufferState(res.ommPostDispatchInfoBuffer, nvrhi::ResourceStates::Common);
 
 				input.operation = omm::GpuBakeNvrhi::Operation::Bake;
 
@@ -281,14 +284,14 @@ namespace {
 				res.ommIndexBuffer = m_device->createBuffer({ .byteSize = info.ommIndexBufferSize, .debugName = "ommIndexBuffer", .canHaveUAVs = true, .canHaveRawViews = true });
 				res.ommDescArrayHistogramBuffer = m_device->createBuffer({ .byteSize = info.ommDescArrayHistogramSize , .debugName = "ommUsageDescBuffer" , .canHaveUAVs = true, .canHaveRawViews = true });
 				res.ommIndexHistogramBuffer = m_device->createBuffer({ .byteSize = info.ommIndexHistogramSize , .debugName = "ommIndexHistogramBuffer" , .canHaveUAVs = true, .canHaveRawViews = true });
-				res.ommPostBuildInfoBuffer = m_device->createBuffer({ .byteSize = info.ommPostBuildInfoBufferSize , .debugName = "ommPostBuildInfoBuffer" , .canHaveUAVs = true, .canHaveRawViews = true });
+				res.ommPostDispatchInfoBuffer = m_device->createBuffer({ .byteSize = info.ommPostDispatchInfoBufferSize , .debugName = "ommPostDispatchInfoBuffer" , .canHaveUAVs = true, .canHaveRawViews = true });
 
 				m_commandList->beginTrackingBufferState(res.ommArrayBuffer, nvrhi::ResourceStates::Common);
 				m_commandList->beginTrackingBufferState(res.ommDescBuffer, nvrhi::ResourceStates::Common);
 				m_commandList->beginTrackingBufferState(res.ommIndexBuffer, nvrhi::ResourceStates::Common);
 				m_commandList->beginTrackingBufferState(res.ommDescArrayHistogramBuffer, nvrhi::ResourceStates::Common);
 				m_commandList->beginTrackingBufferState(res.ommIndexHistogramBuffer, nvrhi::ResourceStates::Common);
-				m_commandList->beginTrackingBufferState(res.ommPostBuildInfoBuffer, nvrhi::ResourceStates::Common);
+				m_commandList->beginTrackingBufferState(res.ommPostDispatchInfoBuffer, nvrhi::ResourceStates::Common);
 
 				bake.Dispatch(
 					m_commandList,
@@ -301,7 +304,7 @@ namespace {
 			nvrhi::BufferHandle ommIndexBufferReadback = m_device->createBuffer({ .byteSize = res.ommIndexBuffer->getDesc().byteSize, .debugName = "omIndexBufferReadback" , .cpuAccess = nvrhi::CpuAccessMode::Read });
 			nvrhi::BufferHandle ommDescArrayHistogramBufferReadback = m_device->createBuffer({ .byteSize = res.ommDescArrayHistogramBuffer->getDesc().byteSize, .debugName = "vmArrayHistogramBufferReadback" , .cpuAccess = nvrhi::CpuAccessMode::Read });
 			nvrhi::BufferHandle ommIndexHistogramBufferReadback = m_device->createBuffer({ .byteSize = res.ommIndexHistogramBuffer->getDesc().byteSize, .debugName = "vmArrayHistogramBufferReadback" , .cpuAccess = nvrhi::CpuAccessMode::Read });
-			nvrhi::BufferHandle ommPostBuildInfoBufferReadback = m_device->createBuffer({ .byteSize = res.ommPostBuildInfoBuffer->getDesc().byteSize, .debugName = "ommPostBuildInfoBufferReadback" , .cpuAccess = nvrhi::CpuAccessMode::Read });
+			nvrhi::BufferHandle ommPostBuildInfoBufferReadback = m_device->createBuffer({ .byteSize = res.ommPostDispatchInfoBuffer->getDesc().byteSize, .debugName = "ommPostBuildInfoBufferReadback" , .cpuAccess = nvrhi::CpuAccessMode::Read });
 			m_commandList->beginTrackingBufferState(ommArrayBufferReadback, nvrhi::ResourceStates::Common);
 			m_commandList->beginTrackingBufferState(ommIndexBufferReadback, nvrhi::ResourceStates::Common);
 			m_commandList->beginTrackingBufferState(ommDescBufferReadback, nvrhi::ResourceStates::Common);
@@ -314,7 +317,7 @@ namespace {
 			m_commandList->copyBuffer(ommIndexBufferReadback, 0, res.ommIndexBuffer, 0, res.ommIndexBuffer->getDesc().byteSize);
 			m_commandList->copyBuffer(ommDescArrayHistogramBufferReadback, 0, res.ommDescArrayHistogramBuffer, 0, res.ommDescArrayHistogramBuffer->getDesc().byteSize);
 			m_commandList->copyBuffer(ommIndexHistogramBufferReadback, 0, res.ommIndexHistogramBuffer, 0, res.ommIndexHistogramBuffer->getDesc().byteSize);
-			m_commandList->copyBuffer(ommPostBuildInfoBufferReadback, 0, res.ommPostBuildInfoBuffer, 0, res.ommPostBuildInfoBuffer->getDesc().byteSize);
+			m_commandList->copyBuffer(ommPostBuildInfoBufferReadback, 0, res.ommPostDispatchInfoBuffer, 0, res.ommPostDispatchInfoBuffer->getDesc().byteSize);
 
 			m_commandList->close();
 
@@ -383,6 +386,27 @@ namespace {
 			omm::Test::ValidateHistograms(&resDesc);
 
 			omm::GpuBakeNvrhi::Stats stats = bake.GetStats(resDesc);
+
+			if (EnablePostBuildInfoStats())
+			{
+				const size_t totalUnknown = stats.totalUnknownOpaque + stats.totalUnknownTransparent;
+				const size_t totalFullyUnknown = stats.totalFullyUnknownOpaque + stats.totalFullyUnknownTransparent;
+				EXPECT_EQ(postBuildInfo.ommTotalOpaqueCount, stats.totalOpaque);
+				EXPECT_EQ(postBuildInfo.ommTotalTransparentCount, stats.totalTransparent);
+				EXPECT_EQ(postBuildInfo.ommTotalUnknownCount, totalUnknown);
+				EXPECT_EQ(postBuildInfo.ommTotalFullyOpaqueCount, stats.totalFullyOpaque);
+				EXPECT_EQ(postBuildInfo.ommTotalFullyTransparentCount, stats.totalFullyTransparent);
+				EXPECT_EQ(postBuildInfo.ommTotalFullyUnknownCount, totalFullyUnknown);
+			}
+			else
+			{
+				EXPECT_EQ(postBuildInfo.ommTotalOpaqueCount, 0);
+				EXPECT_EQ(postBuildInfo.ommTotalTransparentCount, 0);
+				EXPECT_EQ(postBuildInfo.ommTotalUnknownCount, 0);
+				EXPECT_EQ(postBuildInfo.ommTotalFullyOpaqueCount, 0);
+				EXPECT_EQ(postBuildInfo.ommTotalFullyTransparentCount, 0);
+				EXPECT_EQ(postBuildInfo.ommTotalFullyUnknownCount, 0);
+			}
 
 			return
 			{
@@ -1200,37 +1224,40 @@ namespace {
 
 	INSTANTIATE_TEST_SUITE_P(OMMTestGPU, OMMBakeTestGPU, 
 		::testing::Values(	
-							   TestSuiteConfig::None,
-							   TestSuiteConfig::DisableSpecialIndices,
-							   TestSuiteConfig::Force32BitIndices,
-							   TestSuiteConfig::DisableTexCoordDeduplication,
-							   TestSuiteConfig::RedChannel,
-							   TestSuiteConfig::BlueChannel,
-							   TestSuiteConfig::GreenChannel,
-							   
-							   TestSuiteConfig::SetupBeforeBuild,
-							   TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::DisableSpecialIndices,
-							   TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::Force32BitIndices,
-							   TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::DisableTexCoordDeduplication,
-							   TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::RedChannel,
-							   TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::BlueChannel,
-							   TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::GreenChannel,
+							   //TestSuiteConfig::None,
+							   //TestSuiteConfig::DisableSpecialIndices,
+							   //TestSuiteConfig::Force32BitIndices,
+							   //TestSuiteConfig::DisableTexCoordDeduplication,
+							   //TestSuiteConfig::RedChannel,
+							   //TestSuiteConfig::BlueChannel,
+							   //TestSuiteConfig::GreenChannel,
+							   //
+							   //TestSuiteConfig::SetupBeforeBuild,
+							   //TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::DisableSpecialIndices,
+							   //TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::Force32BitIndices,
+							   //TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::DisableTexCoordDeduplication,
+							   //TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::RedChannel,
+							   //TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::BlueChannel,
+							   //TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::GreenChannel,
 								
-							   TestSuiteConfig::ComputeOnly,
-							   TestSuiteConfig::ComputeOnly | TestSuiteConfig::DisableSpecialIndices, 
-							   TestSuiteConfig::ComputeOnly | TestSuiteConfig::Force32BitIndices,
-							   TestSuiteConfig::ComputeOnly | TestSuiteConfig::DisableTexCoordDeduplication,
-							   TestSuiteConfig::ComputeOnly | TestSuiteConfig::RedChannel,
-							   TestSuiteConfig::ComputeOnly | TestSuiteConfig::BlueChannel,
-							   TestSuiteConfig::ComputeOnly | TestSuiteConfig::GreenChannel,
+							   //TestSuiteConfig::ComputeOnly
+							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::DisableSpecialIndices, 
+							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::Force32BitIndices,
+							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::DisableTexCoordDeduplication,
+							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::RedChannel,
+							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::BlueChannel,
+							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::GreenChannel,
+							   // 
+							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild,
+							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::DisableSpecialIndices,
+							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::Force32BitIndices,
+							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::DisableTexCoordDeduplication,
+							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::RedChannel,
+							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::BlueChannel,
+							   // TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::GreenChannel
 
-							   TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild,
-							   TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::DisableSpecialIndices,
-							   TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::Force32BitIndices,
-							   TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::DisableTexCoordDeduplication,
-							   TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::RedChannel,
-							   TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::BlueChannel,
-							   TestSuiteConfig::ComputeOnly | TestSuiteConfig::SetupBeforeBuild | TestSuiteConfig::GreenChannel
+								TestSuiteConfig::EnablePostBuildInfoStats,
+								TestSuiteConfig::ComputeOnly | TestSuiteConfig::EnablePostBuildInfoStats
 						));
 
 }  // namespace


### PR DESCRIPTION
* Renaming POST_BAKE_INFO -> POST_DISPATCH_INFO
* POST_DISPATCH_INFO is now a mandatory input.
* PostDispatchInfo will now contain stats if EnablePostDispatchInfoStats is set.